### PR TITLE
Add recovery breakdown to readiness explanation payload

### DIFF
--- a/backend/backend/services/readiness_daily.py
+++ b/backend/backend/services/readiness_daily.py
@@ -52,7 +52,9 @@ def recompute_readiness_daily_for_date(user_id: str, target_date: str) -> dict[s
 
             cur.execute(
                 """
-                select recovery_score_simple
+                select
+                    recovery_score_simple,
+                    recovery_explanation_json
                 from health_recovery_daily
                 where user_id = %s
                   and date = %s;
@@ -63,6 +65,10 @@ def recompute_readiness_daily_for_date(user_id: str, target_date: str) -> dict[s
 
             freshness = load_row[0] if load_row else None
             recovery_score_simple = recovery_row[0] if recovery_row else None
+            recovery_explanation = recovery_row[1] if recovery_row else None
+
+            if isinstance(recovery_explanation, str):
+                recovery_explanation = json.loads(recovery_explanation)
 
             if freshness is None and recovery_score_simple is None:
                 raise HTTPException(
@@ -104,6 +110,7 @@ def recompute_readiness_daily_for_date(user_id: str, target_date: str) -> dict[s
                     "recovery_score_simple": 0.4,
                 },
                 "formula": "0.6 * freshness_norm + 0.4 * recovery_score_simple",
+                "recovery_explanation": recovery_explanation,
             }
 
             cur.execute(

--- a/docs/models/READINESS_MODEL.md
+++ b/docs/models/READINESS_MODEL.md
@@ -170,6 +170,12 @@ good_day_probability = readiness_score / 100
 - `recovery_score_simple`
 - веса формулы
 - строку формулы
+- `recovery_explanation`
+
+Где:
+
+- `recovery_explanation` протягивается из `health_recovery_daily.recovery_explanation_json`
+- readiness formula при этом не меняется
 
 Это нужно для explainability и отладки.
 

--- a/docs/models/current-metrics-methodology.md
+++ b/docs/models/current-metrics-methodology.md
@@ -266,6 +266,17 @@ Fallback behavior:
 - если нет recovery score, используется `Freshness_norm`
 - если нет load score, используется `RecoveryScoreSimple`
 
+`readiness_daily.explanation_json` при этом хранит:
+
+- `freshness`
+- `freshness_norm`
+- `recovery_score_simple`
+- `weights`
+- `formula`
+- `recovery_explanation`
+
+Где `recovery_explanation` прокидывается из `health_recovery_daily.recovery_explanation_json`, чтобы readiness layer содержал не только итоговый recovery score, но и recovery breakdown.
+
 #### 3.3.3 Final readiness score
 
 ```text
@@ -318,6 +329,6 @@ GoodDayProbability = Readiness / 100
 ### Ограничения текущего подхода
 
 1. `load_input_nonlinear` пока фактически линейный.
-2. Recovery-контур уже baseline-aware, но readiness пока использует его как агрегированный score, а не как full multicomponent formula.
+2. Recovery-контур уже baseline-aware, но readiness formula пока использует его как агрегированный score, а не как full multicomponent formula.
 3. `GoodDayProbability` пока является простым mapping от readiness score.
 4. Decision layer поверх readiness еще не откалиброван окончательно.

--- a/docs/product/CURRENT_STATE.md
+++ b/docs/product/CURRENT_STATE.md
@@ -82,6 +82,7 @@ Pipeline:
 - таблица `health_recovery_daily` уже реализована
 - поле `recovery_score_simple` исторически сохраняет старое имя
 - по смыслу текущий recovery layer уже baseline-aware, а не purely heuristic-only placeholder
+- breakdown recovery baseline сохраняется в `recovery_explanation_json`
 
 ### 2.3 Readiness layer
 
@@ -105,6 +106,7 @@ Pipeline:
 - readiness хранится как отдельный daily storage layer
 - readiness не равен `freshness`
 - readiness объединяет load contour и recovery contour
+- `readiness_daily.explanation_json` теперь включает recovery breakdown из `health_recovery_daily.recovery_explanation_json`
 
 ---
 
@@ -206,6 +208,7 @@ good_day_probability = readiness_score / 100
 - `good_day_probability` уже реализован
 - это baseline probability-like mapping
 - это не статистически откалиброванная вероятность
+- readiness formula не менялась; расширен только explanation payload
 
 ---
 


### PR DESCRIPTION
## Changes
- added `recovery_explanation_json` to recovery layer
- propagated recovery breakdown into `readiness_daily.explanation_json`
- improved explainability of readiness computation
- updated docs to reflect baseline-aware recovery and explainable readiness

## Result
Readiness is now traceable through both:
- load contour
- recovery contour