### PR TITLE
Add decision rules and backend recommendation layer

### DIFF
--- a/backend/backend/services/decision_engine.py
+++ b/backend/backend/services/decision_engine.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def _zone_for_readiness(readiness_score: float) -> str:
+    if readiness_score < 40:
+        return "recovery"
+    if readiness_score < 60:
+        return "endurance"
+    if readiness_score <= 75:
+        return "moderate"
+    return "high_intensity"
+
+
+def _fmt_score(value: float) -> str:
+    if value == int(value):
+        return str(int(value))
+    return f"{value:.1f}"
+
+
+def build_recommendation(readiness_score: float, explanation: dict[str, Any]) -> dict[str, str]:
+    recommendation = _zone_for_readiness(readiness_score)
+
+    reason_parts = [f"Readiness score is {_fmt_score(readiness_score)}/100."]
+
+    fallback_mode = explanation.get("fallback_mode")
+    freshness_norm = explanation.get("freshness_norm")
+    recovery_score = explanation.get("recovery_score_simple")
+
+    if freshness_norm is not None:
+        reason_parts.append(f"Freshness is available at {_fmt_score(float(freshness_norm))}/100.")
+    if recovery_score is not None:
+        reason_parts.append(f"Recovery is available at {_fmt_score(float(recovery_score))}/100.")
+
+    if fallback_mode == "recovery_only":
+        reason_parts.append("Load context is missing, so the recommendation is conservative.")
+    elif fallback_mode == "load_only":
+        reason_parts.append("Recovery context is missing, so freshness should not be over-interpreted.")
+
+    reason_parts.append(f"Recommendation is {recommendation}.")
+
+    return {
+        "recommendation": recommendation,
+        "reason": " ".join(reason_parts),
+    }

--- a/backend/backend/services/readiness_daily.py
+++ b/backend/backend/services/readiness_daily.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException
 
 from backend.core.logging import log_event
 from backend.db import get_conn
+from backend.services.decision_engine import build_recommendation
 
 logger = logging.getLogger(__name__)
 
@@ -186,6 +187,11 @@ def recompute_readiness_daily_for_date(user_id: str, target_date: str) -> dict[s
                 )
                 conn.commit()
 
+        decision = build_recommendation(
+            readiness_score=readiness_score,
+            explanation=explanation_json,
+        )
+
         result = {
             "ok": True,
             "user_id": user_id,
@@ -199,6 +205,7 @@ def recompute_readiness_daily_for_date(user_id: str, target_date: str) -> dict[s
             "status_text": status_text,
             "fallback_mode": fallback_mode,
             "explanation_json": explanation_json,
+            **decision,
         }
         log_event(
             logger,

--- a/backend/backend/services/readiness_query.py
+++ b/backend/backend/services/readiness_query.py
@@ -5,6 +5,7 @@ from typing import Any
 from fastapi import HTTPException
 
 from backend.db import get_conn
+from backend.services.decision_engine import build_recommendation
 
 
 def get_readiness_daily_for_date(user_id: str, target_date: str) -> dict[str, Any]:
@@ -36,6 +37,11 @@ def get_readiness_daily_for_date(user_id: str, target_date: str) -> dict[str, An
 
             db_user_id, db_date, readiness_score, good_day_probability, status_text, explanation_json = row
 
+    decision = build_recommendation(
+        readiness_score=readiness_score,
+        explanation=explanation_json,
+    )
+
     return {
         "ok": True,
         "user_id": db_user_id,
@@ -44,4 +50,5 @@ def get_readiness_daily_for_date(user_id: str, target_date: str) -> dict[str, An
         "good_day_probability": good_day_probability,
         "status_text": status_text,
         "explanation": explanation_json,
+        **decision,
     }

--- a/backend/tests/test_decision_engine.py
+++ b/backend/tests/test_decision_engine.py
@@ -1,0 +1,83 @@
+from backend.services.decision_engine import build_recommendation
+
+
+def test_build_recommendation_maps_recovery_zone():
+    result = build_recommendation(
+        readiness_score=39.9,
+        explanation={
+            "freshness_norm": 42.0,
+            "recovery_score_simple": 35.0,
+            "fallback_mode": None,
+        },
+    )
+
+    assert result["recommendation"] == "recovery"
+    assert "39.9/100" in result["reason"]
+    assert "Freshness is available at 42/100" in result["reason"]
+    assert "Recovery is available at 35/100" in result["reason"]
+
+
+def test_build_recommendation_maps_endurance_boundaries():
+    assert (
+        build_recommendation(readiness_score=40.0, explanation={})["recommendation"]
+        == "endurance"
+    )
+    assert (
+        build_recommendation(readiness_score=59.9, explanation={})["recommendation"]
+        == "endurance"
+    )
+
+
+def test_build_recommendation_maps_moderate_boundaries():
+    assert (
+        build_recommendation(readiness_score=60.0, explanation={})["recommendation"]
+        == "moderate"
+    )
+    assert (
+        build_recommendation(readiness_score=75.0, explanation={})["recommendation"]
+        == "moderate"
+    )
+
+
+def test_build_recommendation_maps_high_intensity_zone():
+    result = build_recommendation(
+        readiness_score=75.1,
+        explanation={
+            "freshness_norm": 84.0,
+            "recovery_score_simple": 80.0,
+            "fallback_mode": None,
+        },
+    )
+
+    assert result["recommendation"] == "high_intensity"
+    assert result["reason"].endswith("Recommendation is high_intensity.")
+
+
+def test_build_recommendation_mentions_recovery_only_fallback():
+    result = build_recommendation(
+        readiness_score=66.4,
+        explanation={
+            "fallback_mode": "recovery_only",
+            "freshness_norm": None,
+            "recovery_score_simple": 66.4,
+        },
+    )
+
+    assert result["recommendation"] == "moderate"
+    assert "Recovery is available at 66.4/100" in result["reason"]
+    assert "Load context is missing" in result["reason"]
+
+
+def test_build_recommendation_mentions_load_only_fallback():
+    result = build_recommendation(
+        readiness_score=62.5,
+        explanation={
+            "fallback_mode": "load_only",
+            "freshness_norm": 62.5,
+            "recovery_score_simple": None,
+        },
+    )
+
+    assert result["recommendation"] == "moderate"
+    assert "Freshness is available at 62.5/100" in result["reason"]
+    assert "Recovery context is missing" in result["reason"]

--- a/backend/tests/test_readiness_fallbacks.py
+++ b/backend/tests/test_readiness_fallbacks.py
@@ -80,6 +80,8 @@ def test_recompute_readiness_daily_uses_full_formula_and_propagates_recovery_exp
     assert result["readiness_score_raw"] == 61.0
     assert result["readiness_score"] == 61.0
     assert result["good_day_probability"] == 0.61
+    assert result["recommendation"] == "moderate"
+    assert "Readiness score is 61/100" in result["reason"]
 
     assert explanation_json["fallback_mode"] is None
     assert explanation_json["freshness"] == 5.0
@@ -103,6 +105,8 @@ def test_recompute_readiness_daily_uses_recovery_only_fallback(monkeypatch):
     assert result["fallback_mode"] == "recovery_only"
     assert result["readiness_score"] == 66.4
     assert result["good_day_probability"] == 0.664
+    assert result["recommendation"] == "moderate"
+    assert "Load context is missing" in result["reason"]
 
     assert explanation_json["fallback_mode"] == "recovery_only"
     assert explanation_json["freshness"] is None
@@ -124,6 +128,8 @@ def test_recompute_readiness_daily_uses_load_only_fallback(monkeypatch):
     assert result["recovery_score_simple"] is None
     assert result["readiness_score"] == 62.5
     assert result["good_day_probability"] == 0.625
+    assert result["recommendation"] == "moderate"
+    assert "Recovery context is missing" in result["reason"]
 
     assert explanation_json["fallback_mode"] == "load_only"
     assert explanation_json["freshness"] == 12.5

--- a/backend/tests/test_readiness_query.py
+++ b/backend/tests/test_readiness_query.py
@@ -1,0 +1,62 @@
+from datetime import date
+
+from backend.services import readiness_query
+
+
+class _FakeCursor:
+    def __init__(self, row) -> None:
+        self._row = row
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, query, params):
+        pass
+
+    def fetchone(self):
+        return self._row
+
+
+class _FakeConn:
+    def __init__(self, row) -> None:
+        self._row = row
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def cursor(self):
+        return _FakeCursor(self._row)
+
+
+def test_get_readiness_daily_for_date_includes_recommendation(monkeypatch):
+    explanation = {
+        "fallback_mode": None,
+        "freshness_norm": 70.0,
+        "recovery_score_simple": 68.0,
+    }
+    row = (
+        "user-1",
+        date(2026, 4, 16),
+        69.2,
+        0.692,
+        "Хорошая готовность",
+        explanation,
+    )
+
+    monkeypatch.setattr(readiness_query, "get_conn", lambda: _FakeConn(row))
+
+    result = readiness_query.get_readiness_daily_for_date(
+        user_id="user-1",
+        target_date="2026-04-16",
+    )
+
+    assert result["recommendation"] == "moderate"
+    assert "Readiness score is 69.2/100" in result["reason"]
+    assert "Freshness is available at 70/100" in result["reason"]
+    assert "Recovery is available at 68/100" in result["reason"]

--- a/docs/models/DECISION_RULES.md
+++ b/docs/models/DECISION_RULES.md
@@ -1,0 +1,261 @@
+# Decision Rules
+
+## 1. Purpose
+
+This document defines the deterministic mapping from `readiness_score` to a training recommendation.
+
+Input:
+
+- `readiness_score` in range `0..100`
+- optional `fallback_mode`
+- optional explanation inputs from load and recovery layers
+
+Output:
+
+- recommendation zone
+- reason string
+- explanation context
+
+This layer consumes readiness. It does not recompute load, recovery, freshness, HRV, sleep, or readiness.
+
+---
+
+## 2. Principles
+
+Decision rules must be:
+
+- rule-based
+- deterministic
+- explainable
+- reproducible
+
+Decision rules must not use:
+
+- ML
+- LLM-generated recommendations
+- hidden probabilistic behavior
+- implicit changes to physiology or metric definitions
+
+---
+
+## 3. Recommendation mapping
+
+Boundary rule:
+
+- exact boundary values use the higher readiness zone, except `75`
+- `75` remains `moderate`
+- `high_intensity` starts only when `readiness_score > 75`
+
+| Readiness score | Zone | Recommendation |
+| --- | --- | --- |
+| `< 40` | `recovery` | Recovery or rest |
+| `40 <= score < 60` | `endurance` | Easy endurance |
+| `60 <= score <= 75` | `moderate` | Moderate aerobic or controlled tempo |
+| `> 75` | `high_intensity` | High intensity if planned |
+
+---
+
+## 4. Zones
+
+### 4.1 Recovery
+
+Meaning:
+
+- readiness is low
+- current state suggests limited ability to absorb additional load
+
+Physiological interpretation:
+
+- fatigue is high, recovery is low, or both
+- the priority is restoring autonomic and muscular readiness
+
+Recommended training type:
+
+- rest
+- mobility
+- very easy spin or walk
+- no intervals
+- no hard strength work
+
+### 4.2 Endurance
+
+Meaning:
+
+- readiness is acceptable but not strong
+- training is possible, but intensity should stay constrained
+
+Physiological interpretation:
+
+- the athlete can likely tolerate low-intensity aerobic work
+- freshness or recovery is not strong enough to justify intensity
+
+Recommended training type:
+
+- easy endurance
+- Zone 1 / Zone 2
+- short aerobic ride or run
+- technique work
+- avoid hard intervals
+
+### 4.3 Moderate
+
+Meaning:
+
+- readiness is solid
+- the athlete can usually handle meaningful aerobic work
+
+Physiological interpretation:
+
+- load and recovery are balanced enough for productive training
+- fatigue is not dominant, but the system is not signaling a peak day
+
+Recommended training type:
+
+- moderate aerobic session
+- controlled tempo
+- endurance with limited intensity
+- strength or skills if already planned
+
+### 4.4 High intensity
+
+Meaning:
+
+- readiness is high
+- the athlete appears prepared for demanding work
+
+Physiological interpretation:
+
+- freshness and recovery are favorable
+- the current state can support higher training stress
+
+Recommended training type:
+
+- intervals
+- threshold / VO2 work
+- race-specific intensity
+- hard strength work if compatible with the plan
+
+High intensity is allowed only if it fits the training plan. Readiness permits intensity; it does not require it.
+
+---
+
+## 5. Explanation rules
+
+The reason string should be assembled from deterministic components:
+
+```text
+<zone summary>. <primary driver>. <training guidance>.
+```
+
+Where:
+
+- `zone summary` comes from the recommendation zone
+- `primary driver` explains whether load/freshness, recovery, or fallback data shaped the result
+- `training guidance` states the recommended training type
+
+Examples:
+
+- `Low readiness. Recovery is the priority today. Choose rest or very easy aerobic work.`
+- `Moderate readiness. Freshness is acceptable, but recovery is not clearly high. Keep intensity controlled.`
+- `High readiness. Freshness and recovery are favorable. High intensity is available if planned.`
+
+Wording rules:
+
+- if recovery is low, mention recovery limitation first
+- if freshness is low, mention load/fatigue limitation first
+- if both are low, prefer recovery-oriented wording
+- if recovery is high but freshness is low, allow only endurance or recovery wording
+- if freshness is high but recovery is low, avoid intensity wording
+- if both are favorable, intensity wording is allowed for `high_intensity`
+
+The reason string should describe the deterministic rule result. It should not generate coaching advice beyond the selected zone.
+
+---
+
+## 6. Edge cases
+
+### 6.1 `fallback_mode = recovery_only`
+
+Meaning:
+
+- recommendation is based only on `recovery_score_simple`
+- load/freshness context is unavailable
+
+Decision behavior:
+
+- use the same readiness-to-zone mapping
+- reason string must state that load context is missing
+- avoid strong intensity wording unless future product rules explicitly allow it
+
+Recommended wording:
+
+```text
+Readiness is based on recovery data only. Load context is missing, so keep the recommendation conservative.
+```
+
+### 6.2 `fallback_mode = load_only`
+
+Meaning:
+
+- recommendation is based only on `freshness_norm`
+- recovery context is unavailable
+
+Decision behavior:
+
+- use the same readiness-to-zone mapping
+- reason string must state that recovery context is missing
+- avoid HRV/sleep-based claims
+
+Recommended wording:
+
+```text
+Readiness is based on load data only. Recovery context is missing, so avoid over-interpreting freshness.
+```
+
+### 6.3 Missing HRV or sleep
+
+Meaning:
+
+- recovery may be partial or less reliable
+- the exact impact is defined by the recovery layer, not by decision rules
+
+Decision behavior:
+
+- do not invent missing HRV or sleep interpretation
+- mention missing recovery inputs only if present in the explanation payload
+- keep wording conservative when recovery confidence is limited
+
+### 6.4 Long inactivity
+
+Meaning:
+
+- freshness may rise during a long break because fatigue decays
+- high readiness may not imply training capacity is fully preserved
+
+Decision behavior:
+
+- use the same readiness-to-zone mapping
+- reason string should mention long inactivity when detected upstream
+- cap wording to controlled return-to-training guidance if product rules expose inactivity context
+
+Recommended wording:
+
+```text
+Readiness is high, but recent training history is limited. Return with controlled endurance before adding intensity.
+```
+
+---
+
+## 7. Constraints
+
+This document defines product decision rules only.
+
+It does not:
+
+- change readiness formula
+- change freshness or recovery definitions
+- introduce new model inputs
+- create a production training plan
+- replace coach judgment
+
+The decision layer remains deterministic decision support on top of `readiness_score`.


### PR DESCRIPTION
## Decision layer v1

Implemented deterministic readiness → recommendation mapping.

### Done

- documented decision rules v1
- added backend recommendation layer
- readiness API now returns:
  - `recommendation`
  - `reason`
- added rule-based mapping:
  - `< 40` → recovery
  - `40–60` → endurance
  - `60–75` → moderate
  - `>= 75` → high intensity possible
- kept logic deterministic and explainable
- updated docs/tests

### Example

```json
{
  "recommendation": "endurance",
  "reason": "Readiness score is 55.7/100. Freshness is available at 52.7/100. Recovery is available at 60.1/100. Recommendation is endurance."
}

Closes #46
Closes #47