### PR TITLE
iOS: add readiness data quality indicators

### DIFF
--- a/ios/Features/ContentView.swift
+++ b/ios/Features/ContentView.swift
@@ -57,6 +57,7 @@ struct ContentView: View {
                     recommendationPanel(readiness)
                     trendPanel
                     signalsPanel(readiness)
+                    dataQualityPanel(readiness)
                     recoveryPanel(readiness)
                     footerView
                 }
@@ -205,6 +206,22 @@ struct ContentView: View {
         }
     }
 
+    @ViewBuilder
+    private func dataQualityPanel(_ readiness: ReadinessDailyResponse) -> some View {
+        if let dataQuality = readiness.dataQuality {
+            terminalPanel {
+                VStack(alignment: .leading, spacing: 10) {
+                    sectionLabel("DATA")
+
+                    dataQualityRow(title: "Sleep", value: dataQuality.sleep)
+                    dataQualityRow(title: "HRV", value: dataQuality.hrv)
+                    dataQualityRow(title: "Rest HR", value: dataQuality.restingHR)
+                    dataQualityRow(title: "Training", value: dataQuality.training)
+                }
+            }
+        }
+    }
+
     private func recoveryPanel(_ readiness: ReadinessDailyResponse) -> some View {
         terminalPanel {
             recoveryBreakdownSection(readiness)
@@ -241,6 +258,24 @@ struct ContentView: View {
                 .font(terminalValueFont)
                 .monospacedDigit()
                 .foregroundStyle(.primary)
+            .lineLimit(1)
+        }
+    }
+
+    @ViewBuilder
+    private func dataQualityRow(title: String, value: String?) -> some View {
+        HStack(spacing: 12) {
+            Text(title)
+                .font(bodyLabelFont)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .frame(width: 110, alignment: .leading)
+
+            Spacer(minLength: 0)
+
+            Text(dataQualityLabel(value))
+                .font(terminalValueFont)
+                .foregroundStyle(dataQualityColor(value))
                 .lineLimit(1)
         }
     }
@@ -321,6 +356,34 @@ struct ContentView: View {
     private func freshnessText(from value: Double?) -> String {
         guard let value else { return "No load data" }
         return String(format: "%.1f", value)
+    }
+
+    private func dataQualityLabel(_ value: String?) -> String {
+        guard let value = trimmedText(value) else { return "n/a" }
+
+        switch value.lowercased() {
+        case "ok":
+            return "OK"
+        case "partial":
+            return "Partial"
+        case "missing":
+            return "Missing"
+        default:
+            return value
+        }
+    }
+
+    private func dataQualityColor(_ value: String?) -> Color {
+        switch trimmedText(value)?.lowercased() {
+        case "ok":
+            return .green
+        case "partial":
+            return .yellow
+        case "missing":
+            return .secondary
+        default:
+            return .primary
+        }
     }
 
     private func readinessExplanationText(for readiness: ReadinessDailyResponse) -> String? {

--- a/ios/Models/ReadinessModels.swift
+++ b/ios/Models/ReadinessModels.swift
@@ -20,6 +20,7 @@ struct ReadinessDailyResponse: Decodable {
     let readinessComment: String?
     let briefingText: String?
     let explanation: ReadinessExplanation?
+    let dataQuality: ReadinessDataQuality?
 
     private enum CodingKeys: String, CodingKey {
         case ok
@@ -35,6 +36,7 @@ struct ReadinessDailyResponse: Decodable {
         case briefingText = "briefing_text"
         case explanation
         case explanationJSON = "explanation_json"
+        case dataQuality = "data_quality"
         case freshness
         case freshnessNorm = "freshness_norm"
         case recoveryScoreSimple = "recovery_score_simple"
@@ -55,6 +57,7 @@ struct ReadinessDailyResponse: Decodable {
         briefing = try container.decodeIfPresent(String.self, forKey: .briefing)
         readinessComment = try container.decodeIfPresent(String.self, forKey: .readinessComment)
         briefingText = try container.decodeIfPresent(String.self, forKey: .briefingText)
+        dataQuality = try container.decodeIfPresent(ReadinessDataQuality.self, forKey: .dataQuality)
 
         if let explanation = try container.decodeIfPresent(ReadinessExplanation.self, forKey: .explanation) {
             self.explanation = explanation
@@ -78,6 +81,20 @@ struct ReadinessDailyResponse: Decodable {
                 self.explanation = nil
             }
         }
+    }
+}
+
+struct ReadinessDataQuality: Decodable {
+    let sleep: String?
+    let hrv: String?
+    let restingHR: String?
+    let training: String?
+
+    enum CodingKeys: String, CodingKey {
+        case sleep
+        case hrv
+        case restingHR = "resting_hr"
+        case training
     }
 }
 


### PR DESCRIPTION
## Summary

Add readiness data quality indicators to iOS Today screen.

## Changes

- Added DATA section to readiness UI
- Display availability status for:
  - Sleep
  - HRV
  - Resting HR
  - Training
- Added decoding for backend data_quality response
- Improved readiness transparency without introducing confidence scores

## UX

The app now explicitly shows which physiological inputs were available for readiness computation.

Example:

DATA
Sleep      OK
HRV        Missing
Training   Partial