### PR TITLE
Fix duplicate HealthKit sync requests

### DIFF
--- a/ios/Features/Dashboard/ContentViewModel.swift
+++ b/ios/Features/Dashboard/ContentViewModel.swift
@@ -50,9 +50,6 @@ final class ContentViewModel {
 
     private var hasPerformedInitialSync = false
     private var hasPreparedDashboard = false
-    private let autoSyncDebounceInterval: TimeInterval = 1.0
-    private let autoSyncThrottleInterval: TimeInterval = 10
-    private var autoSyncWorkItem: DispatchWorkItem?
     private var latestHealthSnapshot: LatestHealthSnapshot?
 
     // MARK: - Sync state
@@ -85,9 +82,7 @@ final class ContentViewModel {
                     guard let self else { return }
                     self.refreshStatuses()
 
-                    if self.syncState.hasPendingAutoSync {
-                        self.triggerAutoSync(reason: "authorization_granted")
-                    }
+                    SyncCoordinator.shared.retryPendingSyncAfterAuthorizationIfNeeded()
                 }
 
             case .failure(let error):
@@ -128,7 +123,9 @@ final class ContentViewModel {
 
         SyncService.shared.sendPayload(
             payload,
-            userID: backendUserID
+            userID: backendUserID,
+            attemptID: UUID().uuidString,
+            source: "content_view_manual_\(mode.rawValue)"
         ) { [weak self] result in
             guard let self else {
                 completion()
@@ -438,17 +435,6 @@ final class ContentViewModel {
         }
 
         loadLatestSnapshotFromHealthKit(completion: completion)
-    }
-
-    func triggerAutoSync(reason: String) {
-        autoSyncWorkItem?.cancel()
-
-        let workItem = DispatchWorkItem { [weak self] in
-            self?.performAutoSyncIfNeeded(reason: reason)
-        }
-
-        autoSyncWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + autoSyncDebounceInterval, execute: workItem)
     }
 
     func runFullSyncFromMainScreen() {
@@ -835,120 +821,6 @@ final class ContentViewModel {
         }
 
         return true
-    }
-
-    private func performAutoSyncIfNeeded(reason: String) {
-        reloadSyncState()
-
-        guard !isSyncInProgress, !SyncCoordinator.shared.isSyncRunning else {
-            return
-        }
-
-        if requiresHealthKitAuthorization {
-            statusMessage = "HealthKit permissions required"
-            syncState.lastSyncAttemptAt = Date()
-            syncState.lastErrorMessage = "HealthKit permissions required"
-            syncState.hasPendingAutoSync = true
-            saveSyncState()
-            refreshStatuses()
-            return
-        }
-
-        if
-            let lastAttempt = syncState.lastSyncAttemptAt,
-            Date().timeIntervalSince(lastAttempt) < autoSyncThrottleInterval,
-            !syncState.hasPendingAutoSync
-        {
-            return
-        }
-
-        syncState.lastSyncAttemptAt = Date()
-        syncState.lastErrorMessage = nil
-        saveSyncState()
-
-        if syncState.lastSuccessfulSyncAt == nil {
-            statusMessage = "Auto sync: full sync..."
-            runAutoFullSync()
-        } else {
-            statusMessage = "Auto sync: incremental sync..."
-            runAutoIncrementalSync(reason: reason)
-        }
-    }
-
-    private func runAutoFullSync() {
-        performFullSync { [weak self] result in
-            guard let self else { return }
-
-            switch result {
-            case .success(let data):
-                self.weightSamples = data.weightSamples
-                self.restingHRSamples = data.restingHRSamples
-                self.hrvSamples = data.hrvSamples
-                self.sleepSamples = data.sleepSamples
-                self.sleepNightAggregates = data.sleepNightAggregates
-                self.persistSnapshot(
-                    rebuiltFrom: data.sleepNightAggregates,
-                    hrvSamples: data.hrvSamples,
-                    restingHRSamples: data.restingHRSamples,
-                    weightSamples: data.weightSamples
-                )
-                self.updatePayloadSummary(from: data.payload)
-                self.refreshStatuses()
-
-                self.sendPayload(data.payload, mode: .full) { [weak self] in
-                    self?.isSyncInProgress = false
-                }
-
-            case .failure:
-                break
-            }
-        }
-    }
-
-    private func runAutoIncrementalSync(reason: String) {
-        performIncrementalSync { [weak self] result in
-            guard let self else { return }
-
-            switch result {
-            case .success(let data):
-                guard let payload = data.payload else {
-                    self.statusMessage = "Auto sync: no new data"
-                    self.syncState.lastSuccessfulSyncAt = Date()
-                    self.syncState.lastErrorMessage = nil
-                    self.syncState.lastSyncMode = .incremental
-                    self.syncState.hasPendingAutoSync = false
-                    self.saveSyncState()
-                    self.isSyncInProgress = false
-                    return
-                }
-
-                self.newHRVSamples = data.newHRVSamples
-                self.newRestingHRSamples = data.newRestingHRSamples
-                self.newSleepNightAggregates = data.newSleepNightAggregates
-                self.hrvSamples = data.newHRVSamples
-                self.restingHRSamples = data.newRestingHRSamples
-                self.sleepNightAggregates = data.newSleepNightAggregates
-                self.sleepSamples = []
-                self.mergeSnapshot(
-                    sleepNightAggregates: data.newSleepNightAggregates,
-                    hrvSamples: data.newHRVSamples,
-                    restingHRSamples: data.newRestingHRSamples
-                )
-                self.updatePayloadSummary(from: payload)
-                self.refreshStatuses()
-
-                self.sendPayload(payload, mode: .incremental) { [weak self] in
-                    self?.isSyncInProgress = false
-                }
-
-            case .failure(let error):
-                self.statusMessage = "Auto sync error: \(error.localizedDescription)"
-                self.syncState.lastErrorMessage = error.localizedDescription
-                self.syncState.hasPendingAutoSync = reason == "authorization_granted"
-                self.saveSyncState()
-                self.isSyncInProgress = false
-            }
-        }
     }
 
     private var latestSleepNightAggregate: SleepNightAggregate? {

--- a/ios/Features/Dashboard/DebugViewModel.swift
+++ b/ios/Features/Dashboard/DebugViewModel.swift
@@ -217,7 +217,9 @@ final class DebugViewModel {
 
         SyncService.shared.sendPayload(
             payload,
-            userID: backendUserID
+            userID: backendUserID,
+            attemptID: UUID().uuidString,
+            source: "debug_view_manual_\(mode.rawValue)"
         ) { [weak self] result in
             guard let self else {
                 completion()

--- a/ios/Services/APIClient.swift
+++ b/ios/Services/APIClient.swift
@@ -108,6 +108,8 @@ final class APIClient {
     func sendHealthPayload(
         _ payload: HealthSyncPayload,
         userID: String,
+        attemptID: String = UUID().uuidString,
+        source: String = "manual_unspecified",
         completion: @escaping (Result<HealthIngestAndProcessResponse, Error>) -> Void
     ) {
         let url = baseURL
@@ -117,7 +119,7 @@ final class APIClient {
             .appendingPathComponent("full-sync")
             .appendingPathComponent(userID)
 
-        print("health_sync_request url=\(url.absoluteString)")
+        print("health_sync_request attempt_id=\(attemptID) source=\(source) url=\(url.absoluteString)")
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -136,7 +138,7 @@ final class APIClient {
         URLSession.shared.dataTask(with: request) { data, response, error in
             DispatchQueue.main.async {
                 if let error {
-                    print("health_sync_request network_error=\(error.localizedDescription)")
+                    print("health_sync_request attempt_id=\(attemptID) source=\(source) network_error=\(error.localizedDescription)")
                     completion(.failure(error))
                     return
                 }
@@ -146,7 +148,7 @@ final class APIClient {
                     return
                 }
 
-                print("health_sync_response status=\(httpResponse.statusCode)")
+                print("health_sync_response attempt_id=\(attemptID) source=\(source) status=\(httpResponse.statusCode)")
 
                 guard let data else {
                     completion(.failure(APIError.emptyResponseBody))

--- a/ios/Services/SyncCoordinator.swift
+++ b/ios/Services/SyncCoordinator.swift
@@ -19,6 +19,8 @@ protocol AutoSyncServicing {
     func sendPayload(
         _ payload: HealthSyncPayload,
         userID: String,
+        attemptID: String,
+        source: String,
         completion: @escaping (Result<HealthIngestAndProcessResponse, Error>) -> Void
     )
 }
@@ -145,10 +147,12 @@ final class SyncCoordinator {
     }
 
     func triggerSync(reason: AutoSyncReason) {
-        print("auto_sync_triggered reason=\(reason.rawValue)")
+        let attemptID = UUID().uuidString
+        refreshPendingStateFromStore()
+        print("auto_sync_triggered attempt_id=\(attemptID) reason=\(reason.rawValue)")
 
         guard healthKitAuthorizationProvider.hasRequestedAuthorization else {
-            print("auto_sync_failed reason=\(reason.rawValue) error=healthkit_permissions_required")
+            print("auto_sync_failed attempt_id=\(attemptID) reason=\(reason.rawValue) error=healthkit_permissions_required")
             hasPendingSync = false
             saveSyncState { syncState in
                 syncState.lastErrorMessage = "HealthKit permissions required"
@@ -159,13 +163,13 @@ final class SyncCoordinator {
         }
 
         if isSyncRunning {
-            shouldSyncAgainAfterCurrentRun = true
-            print("auto_sync_skipped_already_running reason=\(reason.rawValue)")
+            shouldSyncAgainAfterCurrentRun = hasPendingSync || syncStateStore.load().hasPendingAutoSync
+            print("auto_sync_skipped_already_running attempt_id=\(attemptID) reason=\(reason.rawValue)")
             return
         }
 
         if shouldSkipLifecycleCooldown(for: reason) {
-            print("auto_sync_skipped_cooldown reason=\(reason.rawValue)")
+            print("auto_sync_skipped_cooldown attempt_id=\(attemptID) reason=\(reason.rawValue)")
             return
         }
 
@@ -177,24 +181,24 @@ final class SyncCoordinator {
             syncState.lastErrorMessage = nil
         }
 
-        print("auto_sync_started reason=\(reason.rawValue)")
+        print("auto_sync_started attempt_id=\(attemptID) reason=\(reason.rawValue)")
 
         syncService.performRecoverySync { [weak self] result in
             guard let self else { return }
 
             switch result {
             case .success(let data):
-                self.handleRecoveryPayload(data.payload, reason: reason)
+                self.handleRecoveryPayload(data.payload, reason: reason, attemptID: attemptID)
 
             case .failure(let error):
-                print("auto_sync_failed reason=\(reason.rawValue) error=\(error.localizedDescription)")
+                print("auto_sync_failed attempt_id=\(attemptID) reason=\(reason.rawValue) error=\(error.localizedDescription)")
                 self.markPendingSync(errorMessage: error.localizedDescription)
                 self.finishSync(success: false)
             }
         }
     }
 
-    private func handleRecoveryPayload(_ payload: HealthSyncPayload, reason: AutoSyncReason) {
+    private func handleRecoveryPayload(_ payload: HealthSyncPayload, reason: AutoSyncReason, attemptID: String) {
         let itemCounts = recoveryItemCounts(payload)
         let fingerprint = RecoveryPayloadFingerprint.make(from: payload)
         let syncState = syncStateStore.load()
@@ -205,9 +209,9 @@ final class SyncCoordinator {
 
         if !hasNewRecoveryData && !shouldSendPending && !shouldSendFirstPayload {
             if isLifecycleReason(reason), isWithinLifecycleCooldown(syncState) {
-                print("auto_sync_skipped_cooldown reason=\(reason.rawValue)")
+                print("auto_sync_skipped_cooldown attempt_id=\(attemptID) reason=\(reason.rawValue)")
             } else {
-                print("auto_sync_skipped_no_new_data reason=\(reason.rawValue)")
+                print("auto_sync_skipped_no_new_data attempt_id=\(attemptID) reason=\(reason.rawValue)")
             }
 
             hasPendingSync = false
@@ -221,7 +225,7 @@ final class SyncCoordinator {
         }
 
         if !hasPayloadData {
-            print("auto_sync_skipped_no_new_data reason=\(reason.rawValue)")
+            print("auto_sync_skipped_no_new_data attempt_id=\(attemptID) reason=\(reason.rawValue)")
             hasPendingSync = false
             saveSyncState { syncState in
                 syncState.lastErrorMessage = nil
@@ -234,17 +238,22 @@ final class SyncCoordinator {
         }
 
         print(
-            "auto_sync_send_started reason=\(reason.rawValue) " +
+            "auto_sync_send_started attempt_id=\(attemptID) reason=\(reason.rawValue) " +
             "sleep=\(itemCounts.sleep) hrv=\(itemCounts.hrv) rhr=\(itemCounts.restingHR)"
         )
 
-        syncService.sendPayload(payload, userID: backendUserID) { [weak self] sendResult in
+        syncService.sendPayload(
+            payload,
+            userID: backendUserID,
+            attemptID: attemptID,
+            source: "sync_coordinator_\(reason.rawValue)"
+        ) { [weak self] sendResult in
             guard let self else { return }
 
             switch sendResult {
             case .success(let response):
                 print(
-                    "auto_sync_success reason=\(reason.rawValue) " +
+                    "auto_sync_success attempt_id=\(attemptID) reason=\(reason.rawValue) " +
                     "sleep=\(itemCounts.sleep) hrv=\(itemCounts.hrv) rhr=\(itemCounts.restingHR) " +
                     "affected_dates=\(response.affectedDates.count) " +
                     "recovery=\(response.recoveryDaysRecomputed) " +
@@ -264,7 +273,7 @@ final class SyncCoordinator {
                 self.finishSync(success: true)
 
             case .failure(let error):
-                print("auto_sync_failed reason=\(reason.rawValue) error=\(error.localizedDescription)")
+                print("auto_sync_failed attempt_id=\(attemptID) reason=\(reason.rawValue) error=\(error.localizedDescription)")
                 self.markPendingSync(errorMessage: error.localizedDescription)
                 self.finishSync(success: false)
             }
@@ -344,6 +353,7 @@ final class SyncCoordinator {
 
     private func finishSync(success: Bool) {
         isSyncRunning = false
+        refreshPendingStateFromStore()
         notificationCenter.post(name: .syncStateDidChange, object: nil)
 
         if success {
@@ -352,8 +362,16 @@ final class SyncCoordinator {
 
         if shouldSyncAgainAfterCurrentRun {
             shouldSyncAgainAfterCurrentRun = false
+            refreshPendingStateFromStore()
+            guard hasPendingSync else { return }
             triggerSync(reason: .pendingRetry)
         }
+    }
+
+    private func refreshPendingStateFromStore() {
+        let syncState = syncStateStore.load()
+        hasPendingSync = syncState.hasPendingAutoSync
+        lastSyncAttemptAt = syncState.lastSyncAttemptAt
     }
 
     private func saveSyncState(_ mutate: (inout SyncState) -> Void) {

--- a/ios/Services/SyncService.swift
+++ b/ios/Services/SyncService.swift
@@ -208,11 +208,15 @@ final class SyncService {
     func sendPayload(
         _ payload: HealthSyncPayload,
         userID: String,
+        attemptID: String = UUID().uuidString,
+        source: String = "manual_unspecified",
         completion: @escaping (Result<HealthIngestAndProcessResponse, Error>) -> Void
     ) {
         APIClient.shared.sendHealthPayload(
             payload,
             userID: userID,
+            attemptID: attemptID,
+            source: source,
             completion: completion
         )
     }


### PR DESCRIPTION
## Что изменено

- устранены дублирующиеся HealthKit sync-запросы;
- автоматическая синхронизация сериализована через один coordinator;
- добавлена защита от повторной отправки одинакового recovery payload;
- startup, foreground, observer и pending retry больше не запускают параллельные запросы;
- сохранена отдельная ручная синхронизация;
- добавлены attempt ID и source для диагностики.

## Проверка

- изменения основаны на актуальном `main`;
- конфликты разрешены;
- изменения находятся в одном iOS-коммите.